### PR TITLE
docs: reorganize getting started — Docker Compose self-hosting guide …

### DIFF
--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -15,8 +15,6 @@ export default defineConfig({
         text: 'Getting Started',
         items: [
           { text: 'Installation', link: '/getting-started/installation' },
-          { text: 'Dev Setup', link: '/getting-started/dev-setup' },
-          { text: 'Running', link: '/getting-started/running' },
         ],
       },
       {
@@ -44,6 +42,12 @@ export default defineConfig({
           { text: 'Docker', link: '/deployment/docker' },
           { text: 'Environment Variables', link: '/deployment/environment-variables' },
           { text: 'CI/CD', link: '/deployment/ci-cd' },
+        ],
+      },
+      {
+        text: 'Contributing',
+        items: [
+          { text: 'Development Setup', link: '/getting-started/contributing' },
         ],
       },
       {

--- a/apps/docs/getting-started/contributing.md
+++ b/apps/docs/getting-started/contributing.md
@@ -1,0 +1,64 @@
+# Contributing
+
+## Prerequisites
+
+- **Node.js** 20+ (22 recommended)
+- **Docker** and **Docker Compose**
+- **Git**
+
+## Clone the Repository
+
+```bash
+git clone https://github.com/JaccoGoris/comic-shelf.git
+cd comic-shelf
+```
+
+## Install Dependencies
+
+```bash
+npm install
+```
+
+This installs all workspace dependencies for the Nx monorepo (API, web app, shared libs).
+
+## Environment Setup
+
+Copy the example env file and fill in your values:
+
+```bash
+cp .env.example .env
+```
+
+Key variables for local development:
+
+| Variable | Description | Default |
+|---|---|---|
+| `DATABASE_URL` | PostgreSQL connection string | `postgresql://postgres:postgres@localhost:5432/comic_shelf` |
+| `POSTGRES_PASSWORD` | DB password for Docker | `postgres` |
+| `JWT_SECRET` | Secret for signing JWTs | *(required)* |
+| `METRON_USERNAME` | Metron API username | *(optional)* |
+| `METRON_PASSWORD` | Metron API password | *(optional)* |
+
+## Start the Dev Stack
+
+```bash
+npm run dev
+```
+
+This starts:
+- **PostgreSQL** via Docker Compose
+- **NestJS API** on `http://localhost:3000`
+- **Vite web app** on `http://localhost:4200`
+
+## Individual Services
+
+```bash
+# API only
+npm exec nx serve api
+
+# Web app only
+npm exec nx serve web
+
+# Docs site
+npm exec nx serve docs
+```

--- a/apps/docs/getting-started/installation.md
+++ b/apps/docs/getting-started/installation.md
@@ -1,22 +1,118 @@
 # Installation
 
+Comic Shelf is designed to be self-hosted using Docker Compose. All you need is Docker — no Node.js or build tools required.
+
 ## Prerequisites
 
-- **Node.js** 20+ (22 recommended)
-- **Docker** and **Docker Compose** (for the database)
-- **Git**
+- [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/)
 
-## Clone the Repository
+## Quick Start
 
-```bash
-git clone https://github.com/JaccoGoris/comic-shelf.git
-cd comic-shelf
+### 1. Create a `docker-compose.yml`
+
+```yaml
+services:
+  app:
+    image: ghcr.io/jaccogoris/comic-shelf:latest
+    container_name: comic-shelf
+    restart: unless-stopped
+    ports:
+      - '${PORT:-3000}:3000'
+    environment:
+      POSTGRES_HOST: postgres
+      POSTGRES_USER: ${POSTGRES_USER:-comic_shelf}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-comic_shelf}
+      POSTGRES_DB: ${POSTGRES_DB:-comic_shelf}
+      PORT: '3000'
+      JWT_SECRET: ${JWT_SECRET:-changeme}
+      JWT_EXPIRATION: ${JWT_EXPIRATION:-7d}
+      METRON_USERNAME: ${METRON_USERNAME:-}
+      METRON_PASSWORD: ${METRON_PASSWORD:-}
+      METRON_API_BASE_URL: ${METRON_API_BASE_URL:-https://metron.cloud}
+      OIDC_ISSUER_URL: ${OIDC_ISSUER_URL:-}
+      OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:-}
+      OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:-}
+      OIDC_REDIRECT_URI: ${OIDC_REDIRECT_URI:-}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:3000/api/health']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+  postgres:
+    image: postgres:16-alpine
+    container_name: comic-shelf-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-comic_shelf}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-comic_shelf}
+      POSTGRES_DB: ${POSTGRES_DB:-comic_shelf}
+    volumes:
+      - comic_shelf_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:-comic_shelf}']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  comic_shelf_data:
 ```
 
-## Install Dependencies
+### 2. Create a `.env`
 
-```bash
-npm install
+```ini
+# ── Database ──────────────────────────────────────────────
+POSTGRES_USER=comic_shelf
+POSTGRES_PASSWORD=change-me
+POSTGRES_DB=comic_shelf
+
+# ── Auth ──────────────────────────────────────────────────
+# Generate a strong secret, e.g.: openssl rand -hex 32
+JWT_SECRET=change-me-to-a-long-random-secret
+JWT_EXPIRATION=7d
+
+# ── Metron API (optional) ─────────────────────────────────
+# Register at https://metron.cloud to enable UPC barcode lookups
+METRON_USERNAME=
+METRON_PASSWORD=
+
+# ── OIDC (optional) ───────────────────────────────────────
+# Leave OIDC_CLIENT_ID empty to disable OIDC login
+OIDC_ISSUER_URL=
+OIDC_CLIENT_ID=
+OIDC_CLIENT_SECRET=
+OIDC_REDIRECT_URI=
 ```
 
-This installs all workspace dependencies for the Nx monorepo (API, web app, shared libs).
+### 3. Start the stack
+
+```bash
+docker compose up -d
+```
+
+The app will be available at `http://localhost:3000`. On first run, the app will automatically guide you through creating the admin account.
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `POSTGRES_USER` | No | `comic_shelf` | PostgreSQL username |
+| `POSTGRES_PASSWORD` | **Yes** | — | PostgreSQL password |
+| `POSTGRES_DB` | No | `comic_shelf` | PostgreSQL database name |
+| `PORT` | No | `3000` | Port the app listens on |
+| `JWT_SECRET` | **Yes** | — | Secret used to sign JWTs — use a long random string |
+| `JWT_EXPIRATION` | No | `7d` | How long login sessions last |
+| `METRON_USERNAME` | No | — | Metron API username (for UPC lookup) |
+| `METRON_PASSWORD` | No | — | Metron API password (for UPC lookup) |
+| `METRON_API_BASE_URL` | No | `https://metron.cloud` | Metron API base URL |
+| `OIDC_ISSUER_URL` | No | — | OIDC provider issuer URL |
+| `OIDC_CLIENT_ID` | No | — | OIDC client ID (leave empty to disable OIDC) |
+| `OIDC_CLIENT_SECRET` | No | — | OIDC client secret |
+| `OIDC_REDIRECT_URI` | No | — | OIDC callback URL |
+
+See [Environment Variables](/deployment/environment-variables) for the full reference.

--- a/apps/docs/getting-started/running.md
+++ b/apps/docs/getting-started/running.md
@@ -13,7 +13,7 @@ This starts:
 
 ## First-Time Setup
 
-On first run, navigate to `http://localhost:4200/setup` to create the admin account.
+On first run, the app will automatically guide you through creating the admin account.
 
 ## Individual Services
 


### PR DESCRIPTION
…+ Contributing section

- Rewrote installation.md as a self-hosting guide with example docker-compose.yml and .env
- Added env variable table with descriptions inline
- Removed manual /setup navigation note — app guides users automatically on first run
- Created contributing.md with dev clone/install/run instructions (moved from dev-setup + running)
- Updated sidebar: Getting Started now only shows Installation; dev setup moved under Contributing

https://claude.ai/code/session_016ATrBiMjtUfjCAupZWdV6Z